### PR TITLE
Fix modifier keys

### DIFF
--- a/src/happen.js
+++ b/src/happen.js
@@ -19,10 +19,10 @@
                 evt = new Event(o.type);
                 evt.keyCode = o.keyCode || 0;
                 evt.charCode = o.charCode || 0;
-                evt.shift = o.shift || false;
-                evt.meta = o.meta || false;
-                evt.ctrl = o.ctrl || false;
-                evt.alt = o.alt || false;
+                evt.shiftKey = o.shiftKey || false;
+                evt.metaKey = o.metaKey || false;
+                evt.ctrlKey = o.ctrlKey || false;
+                evt.altKey = o.altKey || false;
             } else {
                 evt = document.createEvent('KeyboardEvent');
                 // https://developer.mozilla.org/en/DOM/event.initKeyEvent
@@ -33,10 +33,10 @@
                     true,   //  in boolean canBubbleArg,
                     true,   //  in boolean cancelableArg,
                     null,   //  in nsIDOMAbstractView viewArg,  Specifies UIEvent.view. This value may be null.
-                    o.ctrl || false,  //  in boolean ctrlKeyArg,
-                    o.alt || false,  //  in boolean altKeyArg,
-                    o.shift || false,  //  in boolean shiftKeyArg,
-                    o.meta || false,  //  in boolean metaKeyArg,
+                    o.ctrlKey || false,  //  in boolean ctrlKeyArg,
+                    o.altKey || false,  //  in boolean altKeyArg,
+                    o.shiftKey || false,  //  in boolean shiftKeyArg,
+                    o.metaKey || false,  //  in boolean metaKeyArg,
                     o.keyCode || 0,     //  in unsigned long keyCodeArg,
                     o.charCode || 0       //  in unsigned long charCodeArg);
                 );
@@ -53,10 +53,10 @@
                 o.screenY || 0, // screenY
                 o.clientX || 0, // clientX
                 o.clientY || 0, // clientY
-                o.ctrl || 0, // ctrl
-                o.alt || false, // alt
-                o.shift || false, // shift
-                o.meta || false, // meta
+                o.ctrlKey || 0, // ctrl
+                o.altKey || false, // alt
+                o.shiftKey || false, // shift
+                o.metaKey || false, // meta
                 o.button || false, // mouse button
                 null // relatedTarget
             );

--- a/test/happen.js
+++ b/test/happen.js
@@ -6,7 +6,7 @@ if (typeof require !== 'undefined') {
 }
 
 describe('Happen', function(){
-  describe('mouse shortcuts', function() {
+  describe('shortcuts', function() {
       var shortcuts = ['click', 'mousedown', 'mouseup', 'mousemove', 'mouseover', 'mouseout', 'keyup', 'keypress'];
       for (var i = 0; i < shortcuts.length; i++) {
           (function(i) {
@@ -20,6 +20,23 @@ describe('Happen', function(){
                 happen[shortcuts[i]](a);
                 expect(triggered).to.eql(true);
             });
+
+            var modifiers = ['ctrlKey', 'altKey', 'shiftKey', 'metaKey'];
+            for (var j = 0; j < modifiers.length; j++) {
+                (function(j) {
+                it('supports the ' + modifiers[j] + ' modifier', function(){
+                    var a = document.createElement('a');
+                    var triggered = false;
+                    a['on' + shortcuts[i]] = function(e) {
+                        triggered = e[modifiers[j]];
+                    };
+                    var props = {};
+                    props[modifiers[j]] = true;
+                    happen[shortcuts[i]](a, props);
+                    expect(triggered).to.be(true);
+                });
+              })(j);
+            }
           });
         })(i);
       }
@@ -51,7 +68,7 @@ describe('Happen', function(){
         a.onclick = function(e) {
             shift = e.shiftKey;
         };
-        happen.click(a, { shift: true });
+        happen.click(a, { shiftKey: true });
         expect(shift).to.eql(true);
       });
 


### PR DESCRIPTION
The event properties are shiftKey, altKey, etc., not shift, alt. Set the
correct properties, and rename the options to match.
