### PR TITLE
Fix component install failing because of bad paths in component.json

### DIFF
--- a/component.json
+++ b/component.json
@@ -6,7 +6,8 @@
   "keywords": ["events", "mock", "trigger", "event"],
   "dependencies": {},
   "development": {},
+  "main": "happen.js",
   "scripts": [
-    "src/happen.js"
+    "happen.js"
   ]
 }


### PR DESCRIPTION
For some reason the component.json was pointing to `src/happen.js` which made installation with component fail. It was also missing a `main` field which is required if the main file isn't named `index.js`.
