### PR TITLE
add support for touchstart/touchmove/touchend

### DIFF
--- a/happen.js
+++ b/happen.js
@@ -3,7 +3,8 @@
         events = {
             mouse: ['click', 'mousedown', 'mouseup', 'mousemove',
                 'mouseover', 'mouseout'],
-            key: ['keydown', 'keyup', 'keypress']
+            key: ['keydown', 'keyup', 'keypress'],
+            touch:['touchstart', 'touchmove', 'touchend']
         },
         s, i;
 
@@ -76,25 +77,31 @@
                 evt = document.createEventObject();
                 extend(evt, o);
             } else if (typeof document.createEvent !== 'undefined') {
-                // both MouseEvent and MouseEvents work in Chrome
-                evt = document.createEvent('MouseEvents');
-                // https://developer.mozilla.org/en/DOM/event.initMouseEvent
-                evt.initMouseEvent(o.type,
-                    true, // canBubble
-                    true, // cancelable
-                    window, // 'AbstractView'
-                    o.detail || 0, // click count or mousewheel detail
-                    o.screenX || 0, // screenX
-                    o.screenY || 0, // screenY
-                    o.clientX || 0, // clientX
-                    o.clientY || 0, // clientY
-                    o.ctrlKey || 0, // ctrl
-                    o.altKey || false, // alt
-                    o.shiftKey || false, // shift
-                    o.metaKey || false, // meta
-                    o.button || false, // mouse button
-                    o.relatedTarget // relatedTarget
-                );
+                if (has(events.touch, o.type)) {
+                    evt = document.createEvent('UIEvent');
+                    evt.initUIEvent(o.type, true, true, window, o.detail || 1);
+                    extend(evt, o);
+                } else {
+                    // both MouseEvent and MouseEvents work in Chrome
+                    evt = document.createEvent('MouseEvents');
+                    // https://developer.mozilla.org/en/DOM/event.initMouseEvent
+                    evt.initMouseEvent(o.type,
+                        true, // canBubble
+                        true, // cancelable
+                        window, // 'AbstractView'
+                        o.detail || 0, // click count or mousewheel detail
+                        o.screenX || 0, // screenX
+                        o.screenY || 0, // screenY
+                        o.clientX || 0, // clientX
+                        o.clientY || 0, // clientY
+                        o.ctrlKey || 0, // ctrl
+                        o.altKey || false, // alt
+                        o.shiftKey || false, // shift
+                        o.metaKey || false, // meta
+                        o.button || false, // mouse button
+                        o.relatedTarget // relatedTarget
+                    );
+                }
             }
         }
         return evt;

--- a/test/happen.js
+++ b/test/happen.js
@@ -66,7 +66,7 @@ describe('Happen', function(){
   });
 
   describe('touch events', function() {
-      it('.touchstart()', function(done) {
+      it('touchstart', function(done) {
           addDomEvent(document, 'touchstart', function(param) {
               expect(param.type).to.be.eql('touchstart');
               expect(param.touches).to.have.length(2);
@@ -84,7 +84,7 @@ describe('Happen', function(){
                         }]
           });
       });
-      it('.touchmove', function(done) {
+      it('touchmove', function(done) {
           addDomEvent(document, 'touchmove', function(param) {
               expect(param.type).to.be.eql('touchmove');
               expect(param.touches).to.have.length(2);
@@ -102,7 +102,7 @@ describe('Happen', function(){
                         }]
           });
       });
-      it('.touchend', function(done) {
+      it('touchend', function(done) {
           addDomEvent(document, 'touchend', function(param) {
               expect(param.type).to.be.eql('touchend');
               done();

--- a/test/happen.js
+++ b/test/happen.js
@@ -2,6 +2,15 @@ function getA() {
     return document.body.appendChild(document.createElement('a'));
 }
 
+function addDomEvent(obj, type, handler) {
+  if ('addEventListener' in obj) {
+      //滚轮事件的特殊处理
+      obj.addEventListener(type, handler, false);
+  } else if ('attachEvent' in obj) {
+      obj.attachEvent('on' + type, handler);
+  }
+}
+
 describe('Happen', function(){
   describe('shortcuts', function() {
       var shortcuts = ['click', 'mousedown', 'mouseup', 'mousemove',
@@ -54,6 +63,54 @@ describe('Happen', function(){
               done();
           };
           happen.keyup(document, { keyCode: 30 });
+      });
+  });
+
+  describe('touch events', function() {
+      it('.touchstart()', function(done) {
+          addDomEvent(document, 'touchstart', function(param) {
+              expect(param.type).to.be.eql('touchstart');
+              expect(param.touches).to.have.length(2);
+              done();
+          });
+          happen.once(document, {
+              'type':'touchstart',
+              'touches' : [{
+                            pageX : 100,
+                            pageY : 100,
+                        },
+                        {
+                            pageX : 105,
+                            pageY : 105,
+                        }]
+          });
+      });
+      it('.touchmove', function(done) {
+          addDomEvent(document, 'touchmove', function(param) {
+              expect(param.type).to.be.eql('touchmove');
+              expect(param.touches).to.have.length(2);
+              done();
+          });
+          happen.once(document, {
+              'type':'touchmove',
+              'touches' : [{
+                            pageX : 100,
+                            pageY : 100,
+                        },
+                        {
+                            pageX : 105,
+                            pageY : 105,
+                        }]
+          });
+      });
+      it('.touchend', function(done) {
+          addDomEvent(document, 'touchend', function(param) {
+              expect(param.type).to.be.eql('touchend');
+              done();
+          });
+          happen.once(document, {
+              'type':'touchend'
+          });
       });
   });
 

--- a/test/happen.js
+++ b/test/happen.js
@@ -4,7 +4,6 @@ function getA() {
 
 function addDomEvent(obj, type, handler) {
   if ('addEventListener' in obj) {
-      //滚轮事件的特殊处理
       obj.addEventListener(type, handler, false);
   } else if ('attachEvent' in obj) {
       obj.attachEvent('on' + type, handler);


### PR DESCRIPTION
Thanks for this excellent library, really save my life in my own tests.

This is a patch to support for touch events which are a little bit different from mouse events.

Should be useful for test scenarios targeting touchable devices.